### PR TITLE
Fix `classifier` Property Issue in Gradle Build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,13 +108,13 @@ allprojects {
 
   task sourcesJar(type: Jar, dependsOn: classes) {
     archiveBaseName = 'besu-verkle.trie'
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from sourceSets.main.allSource
   }
 
   task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveBaseName = 'besu-verkle.trie'
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
     from javadoc.destinationDir
   }
 


### PR DESCRIPTION
## Description
This PR addresses a build failure in the `besu-verkle-trie` project while executing the `gradle` command. The error was caused by the use of the deprecated `classifier` property in the `build.gradle` file.

### Error Details
Running the `gradle` command resulted in the following error:

```plaintext
$ gradle

FAILURE: Build failed with an exception.

* Where:
Build file './besu-verkle-trie/build.gradle' line: 111

* What went wrong:
A problem occurred evaluating root project 'besu-verkle-trie'.
> Could not set unknown property 'classifier' for task ':sourcesJar' of type org.gradle.api.tasks.bundling.Jar.
...
```

### Cause
The issue was due to the use of the `classifier` key, which has been deprecated. The problematic code snippet was:

```groovy
  task sourcesJar(type: Jar, dependsOn: classes) {
    archiveBaseName = 'besu-verkle.trie'
    classifier = 'sources'
    from sourceSets.main.allSource
  }

  task javadocJar(type: Jar, dependsOn: javadoc) {
    archiveBaseName = 'besu-verkle.trie'
    classifier = 'javadoc'
    from javadoc.destinationDir
  }
```

### Resolution
The `classifier` property has been replaced with `archiveClassifier` to maintain compatibility with the latest version of Gradle. The updated code is as follows:

```groovy
  task sourcesJar(type: Jar, dependsOn: classes) {
    archiveBaseName = 'besu-verkle.trie'
    archiveClassifier = 'sources'
    from sourceSets.main.allSource
  }

  task javadocJar(type: Jar, dependsOn: javadoc) {
    archiveBaseName = 'besu-verkle.trie'
    archiveClassifier = 'javadoc'
    from javadoc.destinationDir
  }
```

## Impact
This change ensures compatibility with Gradle 9.0 and resolves the build failure issue.